### PR TITLE
Replace Ruby based bourbon by node bourbon

### DIFF
--- a/app/styles/css/_header.scss
+++ b/app/styles/css/_header.scss
@@ -1,4 +1,5 @@
-@import '../vendor/bourbon/bourbon';
+@import 'bourbon';
+
 @import 'variables';
 @import 'utils';
 

--- a/app/styles/css/_modals-base.scss
+++ b/app/styles/css/_modals-base.scss
@@ -1,4 +1,4 @@
-@import '../vendor/bourbon/bourbon';
+@import 'bourbon';
 
 @import 'variables';
 @import 'utils';

--- a/app/styles/css/_modals.scss
+++ b/app/styles/css/_modals.scss
@@ -1,4 +1,4 @@
-@import '../vendor/bourbon/bourbon';
+@import 'bourbon';
 
 @import 'variables';
 @import 'utils';

--- a/app/styles/css/_queue.scss
+++ b/app/styles/css/_queue.scss
@@ -1,5 +1,6 @@
-@import '../vendor/bourbon/addons/position';
-@import '../vendor/bourbon/addons/triangle';
+@import 'addons/triangle';
+@import 'addons/position';
+
 @import 'utils';
 
 @mixin queue-item-color($color-background) {

--- a/app/styles/css/_scene.scss
+++ b/app/styles/css/_scene.scss
@@ -1,4 +1,5 @@
-@import '../vendor/bourbon/addons/position';
+@import 'addons/position';
+
 @import 'variables';
 @import 'utils';
 

--- a/app/styles/css/_search.scss
+++ b/app/styles/css/_search.scss
@@ -1,4 +1,5 @@
-@import '../vendor/bourbon/bourbon';
+@import 'bourbon';
+
 @import 'variables';
 @import 'utils';
 

--- a/app/styles/css/main.scss
+++ b/app/styles/css/main.scss
@@ -1,4 +1,5 @@
-@import '../vendor/bourbon/bourbon';
+@import 'bourbon';
+
 @import 'variables';
 @import 'utils';
 @import 'base';

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,6 +19,7 @@ const path = require('path'),
   uglify = require('gulp-uglify'),
   ngAnnotate = require('gulp-ng-annotate'),
   sass = require('gulp-sass'),
+  bourbon = require('node-bourbon'),
   postcss = require('gulp-postcss'),
   autoprefixer = require('autoprefixer'),
   csswring = require('csswring'),
@@ -114,7 +115,7 @@ function doInlineCss(opts) {
 
   return gulp.src('app/styles/css/inline.scss')
     .pipe(plumber())
-    .pipe(sass())
+    .pipe(sass({includePaths: bourbon.includePaths}))
     .pipe(postcss(postCssFilters));
 }
 
@@ -174,7 +175,7 @@ function cssDev() {
   return gulp.src('app/styles/css/main.scss')
     .pipe(plumber())
     .pipe(sourcemaps.init())
-    .pipe(sass())
+    .pipe(sass({includePaths: bourbon.includePaths}))
     .pipe(postcss([
       autoprefixer({browsers: ['last 1 version']})
     ]))
@@ -248,7 +249,7 @@ function cssDist() {
   return gulp.src('app/styles/css/main.scss')
     .pipe(plumber())
     .pipe(sourcemaps.init())
-    .pipe(sass())
+    .pipe(sass({includePaths: bourbon.includePaths}))
     .pipe(postcss([
       autoprefixer({browsers: ['last 1 version']}),
       csswring

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "jshint-stylish": "^2.0.0",
     "merge-stream": "^1.0.0",
     "minimist": "^1.2.0",
+    "node-bourbon": "^4.2.3",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.0.0",
     "watchify": "^3.2.2"


### PR DESCRIPTION
#### What's this PR do?
Use node bourbon to ease build / install process: everything is now managed by NPM. No need to use Ruby