### PR TITLE
Made angular deps semver more restrictive

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -9,9 +9,9 @@
   "license": "MIT",
   "dependencies": {
     "Ionicons": "jraoult/ionicons#npm",
-    "angular": "^1.4.5",
-    "angular-animate": "^1.4.5",
-    "angular-aria": "^1.4.5",
+    "angular": "~1.5.10",
+    "angular-animate": "~1.5.10",
+    "angular-aria": "~1.5.10",
     "fg-loadcss": "^1.2.1",
     "keymaster": "^1.6.2",
     "lodash": "^4.15.0",


### PR DESCRIPTION
As long as we haven't migrated to Angular 1.6 we have to be more conservative than normal semver since they don't respect it (minor version removes API)