### PR TITLE
Fix an animation failure on the first added entry

### DIFF
--- a/app/src/scripts/components/scrollableDirective.js
+++ b/app/src/scripts/components/scrollableDirective.js
@@ -25,7 +25,7 @@ function scrollableDirective($timeout, animationsConfig) {
   function containsY(container, content) {
     var containerRect = container[0].getBoundingClientRect();
     var contentRect = content[0].getBoundingClientRect();
-    return containerRect.top < contentRect.top && contentRect.bottom < containerRect.bottom;
+    return containerRect.top <= contentRect.top && contentRect.bottom <= containerRect.bottom;
   }
 
   return {


### PR DESCRIPTION
#### What's this PR do?
A change in scroll-into-view (cf https://github.com/KoryNunn/scroll-into-view/commit/c2148af080fc91cdf015fc54d9a31c9761c767b0) forces relayout and that somehow prevents Angular from animating the first added entry. I haven't dug a lot to get the exact details of the angular problem.

By fixing our own broken `containsY` test we work around the problem
