### PR TITLE
Blacklisted video detection - new approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ will be use if the argument is not defined
 - **analyticsTrackerPath** overrides the default analytics tracker implementation (`string`). A noop default
 implementation will be use if the argument is not defined
 - **logoPath**: specifies the logo of the application (`string`, `src/images/mt-empty-logo.svg` by default)
-- **youtubeExtraVideosInfoUrl**: specifies the YouTube extra info endpoint URL. I none provided it is simply ignored (`string`)
 
 You can always get the descriptions of the build options by invoking:
 

--- a/app/package.json
+++ b/app/package.json
@@ -15,7 +15,8 @@
     "fg-loadcss": "^1.2.1",
     "keymaster": "^1.6.2",
     "lodash": "^4.15.0",
-    "mixtube-playback": "mixtube/mixtube-playback#v1.0.1",
+    "mixtube-playback": "mixtube/mixtube-playback#v2.0.2",
+    "on-idle": "^1.1.0",
     "scroll-into-view": "^1.5.0"
   }
 }

--- a/app/src/scripts/components/configurationFactory.js
+++ b/app/src/scripts/components/configurationFactory.js
@@ -21,12 +21,6 @@ function configurationFactory($location, environment) {
     get youtubeAPIKey() {
       return environment.youtubeAPIKey;
     },
-    get youtubeExtraVideosInfoUrl() {
-      if (has(debugParams, 'youtubeExtraVideosInfoUrl')) {
-        return debugParams.youtubeExtraVideosInfoUrl;
-      }
-      return environment.youtubeExtraVideosInfoUrl;
-    },
     get maxSearchResults() {
       return 20;
     },

--- a/app/src/scripts/components/playback/orchestratorFactory.js
+++ b/app/src/scripts/components/playback/orchestratorFactory.js
@@ -3,7 +3,7 @@
 var angular = require('angular'),
   difference = require('lodash/difference'),
   includes = require('lodash/includes'),
-  mixtubePlayback = require('mixtube-playback');
+  engine = require('mixtube-playback').engine;
 
 // @ngInject
 function orchestratorFactory($rootScope, $timeout, queueManager, notificationCentersRegistry, scenesRegistry,
@@ -42,7 +42,7 @@ function orchestratorFactory($rootScope, $timeout, queueManager, notificationCen
             _playbackState = state;
 
             // when the playbacks stops we need to tell that the last playing video is not playing anymore
-            if (_playbackState === mixtubePlayback.States.stopped) {
+            if (_playbackState === engine.States.stopped) {
               _playingEntry = null;
             }
           });
@@ -96,7 +96,7 @@ function orchestratorFactory($rootScope, $timeout, queueManager, notificationCen
         };
       }
 
-      _playback = mixtubePlayback(playbackConfig);
+      _playback = engine(playbackConfig);
 
       $rootScope.$watchCollection(function() {
         return queueManager.queue.entries;
@@ -124,16 +124,16 @@ function orchestratorFactory($rootScope, $timeout, queueManager, notificationCen
     } else {
       _playback.skip(entry);
 
-      if (_playbackState !== mixtubePlayback.States.playing) {
+      if (_playbackState !== engine.States.playing) {
         _playback.play();
       }
     }
   }
 
   function togglePlayback() {
-    if (_playbackState === mixtubePlayback.States.playing) {
+    if (_playbackState === engine.States.playing) {
       _playback.pause();
-    } else if (_playbackState === mixtubePlayback.States.paused) {
+    } else if (_playbackState === engine.States.paused) {
       _playback.play();
     } else if (queueManager.queue.entries.length) {
       // stopped or pristine
@@ -172,14 +172,14 @@ function orchestratorFactory($rootScope, $timeout, queueManager, notificationCen
      * @returns {boolean}
      */
     get playing() {
-      return _playbackState === mixtubePlayback.States.playing;
+      return _playbackState === engine.States.playing;
     },
 
     /**
      * @returns {boolean}
      */
     get stopped() {
-      return _playbackState === mixtubePlayback.States.stopped;
+      return _playbackState === engine.States.stopped;
     },
 
     /**

--- a/app/src/scripts/main.js
+++ b/app/src/scripts/main.js
@@ -5,8 +5,7 @@ var mixtube = require('./mixtube'),
   errorsTracker = require('./delegates/errorsTracker');
 
 mixtube({
-  youtubeAPIKey: process.env.YOUTUBE_API_KEY,
-  youtubeExtraVideosInfoUrl: process.env.YOUTUBE_EXTRA_VIDEOS_INFO_URL
+  youtubeAPIKey: process.env.YOUTUBE_API_KEY
 }, {
   analyticsTracker: analyticsTracker(),
   // log collected exception to the browser console by default

--- a/build/gulpfile.js
+++ b/build/gulpfile.js
@@ -70,10 +70,6 @@ const commandLine = yargs
       default: 'hsl(199, 100%, 50%)',
       describe: 'specifies the accent color for the whole application',
       type: 'string'
-    },
-    youtubeExtraVideosInfoUrl: {
-      describe: 'specifies the YouTube extra info endpoint URL. I none provided it is simply ignored',
-      type: 'string'
     }
   });
 
@@ -91,7 +87,6 @@ const config = {
   analyticsTrackerPath: cmdArgumentsValues.analyticsTrackerPath,
   injectHeadPath: cmdArgumentsValues.injectHeadPath,
   logoPath: cmdArgumentsValues.logoPath,
-  youtubeExtraVideosInfoUrl: cmdArgumentsValues.youtubeExtraVideosInfoUrl,
   logoUrl: path.basename(cmdArgumentsValues.logoPath),
   youtubeApiKey: process.env.MIXTUBE_YOUTUBE_API_KEY
 };

--- a/build/src/buildJs.js
+++ b/build/src/buildJs.js
@@ -18,7 +18,7 @@ const gulp = require('gulp'),
 
 /**
  * @param {{appDirPath: string, publicDirPath: string, watch: boolean, production: boolean, appVersion: string,
- * youtubeApiKey: string, youtubeExtraVideosInfoUrl: string, errorsTrackerPath: ?string, analyticsTrackerPath: ?string}} config
+ * youtubeApiKey: string, errorsTrackerPath: ?string, analyticsTrackerPath: ?string}} config
  * @returns {function}
  */
 module.exports = function makeBuildJs(config) {
@@ -57,8 +57,7 @@ module.exports = function makeBuildJs(config) {
 
     const environment = {
       APP_VERSION: config.appVersion,
-      YOUTUBE_API_KEY: config.youtubeApiKey,
-      YOUTUBE_EXTRA_VIDEOS_INFO_URL: config.youtubeExtraVideosInfoUrl
+      YOUTUBE_API_KEY: config.youtubeApiKey
     };
 
     return merge(


### PR DESCRIPTION
#### What's this PR do?
Uses the new capabilities of `mixtube-playback` to check if a video will be playable on the current domain. Since this test is "heavy" (in CPU, RAM and network) we keep it to the first time the queue is loaded and every time a video is added. We had to skip the search.

#### Is any other information necessary to understand this?
The previous attempt to fix this (based on an ad-hoc REST API) was more elegant but didn't work: `get info` has to be called form the IP where the video is going to be played, otherwise so geo restriction might be wrongly computed.

We instead attempt to load and play the video and check if it returns an error.
